### PR TITLE
fix_do_not_create_if_bulk_list_None

### DIFF
--- a/sqlbatis/sqlbatis_dao.py
+++ b/sqlbatis/sqlbatis_dao.py
@@ -115,9 +115,12 @@ class SQLBatisDao(metaclass=SQLBatisMetaClass):
         :return: TBI
         :rtype: TBI
         """
-        with self.SQLBatis.get_connection() as conn:
-            result = conn.execute(self.table.insert().values(attrs))
-            return result
+        if len(attrs) > 0:
+            with self.SQLBatis.get_connection() as conn:
+                result = conn.execute(self.table.insert().values(attrs))
+                return result
+
+        return None
 
     def _get_table_name(self):
         """

--- a/tests/crud.py
+++ b/tests/crud.py
@@ -53,4 +53,6 @@ users = [{
     'name': 'leo3'
 }]
 
+users_null = []
+
 users_for_paged = [user for i in range(35)]

--- a/tests/test_basic_dao.py
+++ b/tests/test_basic_dao.py
@@ -50,6 +50,14 @@ class BasicDaoTestCase(BasicTestCase):
         results = user_dao.retrieve_all().all()
         assert len(results) == 4
 
+    def test_6_bulk_insert_null(self):
+        user_dao = UserDao()
+        pre_res = user_dao.retrieve_all().all()
+        user_dao.bulk_insert(users_null)
+        results = user_dao.retrieve_all().all()
+
+        assert len(results) == len(pre_res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When I create data in batch, a piece of data will be created by default when the data list is empty